### PR TITLE
docs: restart project planning, scoped to solo dogfood MVP

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,117 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             Intrik8 Labs LLC
+Licensed Work:        Yggdrasil
+                      The Licensed Work is (c) 2026 Intrik8 Labs LLC
+Additional Use Grant: You may make production use of the Licensed Work,
+                      without purchasing a commercial license, for:
+
+                      (a) personal, non-commercial use, including
+                      self-hosted ("homelab") deployments;
+
+                      (b) evaluation or testing to determine the Licensed
+                      Work's suitability for your organization's use case; or
+
+                      (c) internal use by a non-profit organization (as
+                      recognized under the laws of its jurisdiction) for
+                      that organization's own operations.
+
+                      Any other production use, including use by a
+                      for-profit business or managed service provider to
+                      run its own operations or deliver services to its
+                      own clients, requires a commercial license from
+                      Licensor.
+
+                      Regardless of the foregoing, you may not, without a
+                      separate written agreement with Licensor, offer the
+                      Licensed Work, or any product or service that
+                      competes with a hosted, managed, or
+                      software-as-a-service offering made available by
+                      Licensor, to third parties as a hosted, managed, or
+                      software-as-a-service product.
+Change Date:          2030-06-22
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact <license@intrik8-labs.com>.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may
+vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source
+License", as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to
+all other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later
+   version, or a license that is compatible with GPL Version 2.0 or a later
+   version, where "compatible" means that software provided under the
+   Change License can be included in a program with software provided under
+   GPL Version 2.0 or a later version. Licensor may specify additional
+   Change Licenses without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License,
+   as the Additional Use Grant, or (b) insert the text "None" to specify
+   that there is no Additional Use Grant.
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Yggdrasil
+
+A self-hosted tool for tracking what's running and what's left to do
+across the author's own homelab — built solo, dogfooded first. The
+longer-term direction is a unified, self-hosted operations platform (RMM,
+PSA, CRM, ERP) for people and organizations tired of stitching together
+separate tools, but that's a direction to grow into, not the current
+scope. See [`docs/planning/CHARTER.md`](docs/planning/CHARTER.md) and
+[`docs/planning/ROADMAP.md`](docs/planning/ROADMAP.md).
+
+## Status
+
+Planning restart, scoped down from an earlier, much larger plan. Current
+phase: a minimal single-user loop across three modules — agent,
+monitoring, tasks. Scope and architecture decisions are tracked as
+Architecture Decision Records — see [`docs/decisions/`](docs/decisions/).
+
+## In Scope Right Now
+
+- **Smidr** — agent, connects outbound only, reports basic health/inventory
+- **Heimdallr** — monitoring, displays what Smidr reports
+- **Mimir** — task/ticket tracking, linked to the machines it relates to
+- **Tyr** — minimal single-user login
+
+The full original module catalog is kept as reference, not commitment —
+see [`docs/modules/MODULES.md`](docs/modules/MODULES.md).
+
+## License
+
+Currently licensed under the [Business Source License 1.1](LICENSE)
+(BUSL), inherited from the earlier, larger-scoped plan. This is being
+reconsidered for the current solo/dogfood scope — see
+[`docs/decisions/adr-0005-deferred-decisions-log.md`](docs/decisions/adr-0005-deferred-decisions-log.md) —
+and should be treated as provisional. [LICENSE](LICENSE) remains the
+binding text until that's revisited.
+
+## Contributing
+
+Not open to outside contributions yet — this is solo, dogfood-stage work.
+Contribution guidelines will be added if/when that changes.

--- a/docs/decisions/adr-0001-record-architecture-decisions.md
+++ b/docs/decisions/adr-0001-record-architecture-decisions.md
@@ -1,0 +1,127 @@
+# ADR-0001 — Record Architecture Decisions
+
+| Field         | Value         |
+| ------------- | ------------- |
+| Status        | ACCEPTED      |
+| Date          | 2026-06-28    |
+| Deciders      | Jason Scherer |
+| Superseded By |               |
+
+## Revision History
+
+| Version | Date       | Author        | Notes                                             |
+| ------- | ---------- | ------------- | -------------------------------------------------- |
+| 1.0     | 2026-06-28 | Jason Scherer | Restart of ADR-0001, rescoped for solo/MVP phase   |
+
+---
+
+## Context
+
+Yggdrasil is restarting from a from-scratch planning pass after an earlier
+attempt scoped a 23-module platform and went through three language
+migrations before anything was dogfooded. This restart is
+deliberately smaller in scope (see `docs/planning/CHARTER.md`) and solo,
+at roughly 5-10 hours/week.
+
+Even at this scale, decisions will be made about architecture, scope, and
+what to defer — and a solo, part-time project loses context just as
+easily as a larger one, maybe more so, since weeks can pass between
+sessions of work.
+
+## Decision Drivers
+
+- Decisions need to be discoverable after gaps of weeks between work
+  sessions, without relying on memory
+- The record format needs to be lightweight enough to actually get used
+  under a tight time budget, not skipped
+- Scope decisions and deferrals matter as much as technical ones at this
+  stage — both need a permanent record
+- The format should stay readable without requiring any specific tooling
+
+## Decision
+
+Yggdrasil will use Architecture Decision Records, stored in
+`docs/decisions/`, to document significant scope, product, and technical
+decisions — including explicit decisions to defer something.
+
+ADR files use this naming convention:
+
+- `adr-0001-record-architecture-decisions.md`
+- `adr-0002-mvp-single-tenant-scope.md`
+- `adr-0003-outbound-only-agent-comms.md`
+
+Each ADR includes:
+
+- Document metadata table
+- Revision history
+- Context
+- Decision Drivers
+- Decision
+- Consequences
+- Alternatives considered
+- Related links, when useful
+
+The ADR template lives at `docs/decisions/adr-template.md`.
+
+Status values use uppercase names: `PROPOSED`, `ACCEPTED`, `SUPERSEDED`,
+`DEPRECATED`, `REJECTED`.
+
+A special case of this is the deferred decisions log
+(`adr-0005-deferred-decisions-log.md`), which records decisions
+deliberately *not* made yet, along with the condition that would trigger
+revisiting each one. This exists specifically because this project is
+solo and scope-constrained — deferring honestly, with a written trigger,
+is preferable to either pretending the decision is made or letting it
+quietly disappear.
+
+---
+
+## Consequences
+
+**Positive:**
+
+- Scope and architecture decisions have a permanent home, recoverable
+  across multi-week gaps in work
+- Deferred decisions are tracked deliberately instead of forgotten
+- Direction can change without losing the history of why
+
+**Accepted tradeoffs:**
+
+- Adds documentation overhead on a project with very little spare time
+- Requires discipline to write an ADR instead of just coding
+
+**Negative:**
+
+- ADRs can go stale if not updated when a decision changes
+- Too many ADRs for minor implementation details would create noise —
+  this is being avoided by reserving ADRs for scope/architecture-level
+  decisions, not implementation choices
+
+**Neutral / follow-up:**
+
+- Initial ADRs cover MVP scope, agent communication, module/communication
+  boundaries, and the deferred decisions log
+
+---
+
+## Alternatives Considered
+
+**Do not record architecture decisions**
+
+Simpler short term, but given how little time is available per week,
+context would be lost between sessions even faster than on a
+fully-staffed project. Rejected.
+
+**Use only GitHub issues or informal notes**
+
+Faster to write, but not durable or structured enough to serve as the
+record of *why* something was decided or deferred, especially across
+long gaps. Rejected as the primary mechanism.
+
+---
+
+## Related
+
+- `docs/decisions/adr-template.md`
+- `docs/decisions/adr-0005-deferred-decisions-log.md`
+- `docs/planning/CHARTER.md`

--- a/docs/decisions/adr-0002-mvp-single-tenant-scope.md
+++ b/docs/decisions/adr-0002-mvp-single-tenant-scope.md
@@ -1,0 +1,112 @@
+# ADR-0002 — Single-User, Single-Tenant Scope for the MVP
+
+| Field         | Value         |
+| ------------- | ------------- |
+| Status        | ACCEPTED      |
+| Date          | 2026-06-28    |
+| Deciders      | Jason Scherer |
+| Superseded By |               |
+
+## Revision History
+
+| Version | Date       | Author        | Notes   |
+| ------- | ---------- | ------------- | ------- |
+| 1.0     | 2026-06-28 | Jason Scherer | Initial |
+
+---
+
+## Context
+
+The original plan designed a three-tier tenancy model: Platform Owner →
+Tenant (MSP) → SubTenant (MSP's client), with structural data isolation
+enforced at the query layer. That model exists to let an MSP manage
+multiple clients in aggregate while keeping different MSPs' data strictly
+separated from each other.
+
+Right now there is exactly one user of this platform: the author, running
+it for their own homelab and personal task tracking. There is no second
+organization, no client, and no near-term plan to onboard one inside this
+phase's scope (`docs/planning/CHARTER.md`, Phase 1 of
+`docs/planning/ROADMAP.md`).
+
+## Decision Drivers
+
+- Solo project at 5-10 hrs/week — every piece of machinery built has to
+  earn its cost against real, current usage
+- Tenant isolation logic (scoping every query, structural enforcement,
+  admin tooling for cross-tenant visibility) is real engineering effort
+  with zero current beneficiary
+- The three-tier model is still the right answer if/when a second
+  organization shows up — the concept isn't being rejected, just deferred
+- Retrofitting tenancy later is a real cost, but is one this project is
+  explicitly willing to pay in exchange for not carrying unused isolation
+  machinery through the entire dogfood phase
+
+## Decision
+
+The MVP and Phase 1 build will be single-user, single-tenant. No
+Platform Owner / Tenant / SubTenant hierarchy, no per-tenant data
+isolation enforcement, no admin tooling for managing other
+tenants/organizations.
+
+This is recorded in the deferred decisions log
+(`adr-0005-deferred-decisions-log.md`) with its trigger: revisit the
+three-tier model when a real second user or organization needs to use
+the platform — not before.
+
+## Consequences
+
+**Positive:**
+
+- Removes a substantial, currently-unneeded category of work from the
+  MVP
+- Keeps the data model and access logic simple while there's only one
+  real user to validate against
+
+**Accepted tradeoffs:**
+
+- If/when a second tenant does show up, introducing tenancy retroactively
+  will cost more than building it in from the start would have
+- This is accepted deliberately — see Decision Drivers — because the
+  alternative is paying that cost now, with certainty, for a benefit that
+  is not yet certain to materialize
+
+**Negative:**
+
+- None identified beyond the accepted tradeoff above, given current scope
+
+**Neutral / follow-up:**
+
+- When Phase 3 conditions are met (see `docs/planning/ROADMAP.md`),
+  revisit the original three-tier model design as a starting point rather
+  than redesigning from zero — it was reasoned through once already
+
+---
+
+## Alternatives Considered
+
+**Build the three-tier model now, even for one user**
+
+This was the original plan's approach and is the safer long-term choice
+if multi-tenancy is a near-certainty. It was rejected for this phase
+because multi-tenancy is not a near-certainty yet — it's a long-term
+direction (see CHARTER.md) without confirmed demand, and building it now
+would spend a meaningful share of a very limited weekly time budget on
+isolation machinery nobody is currently being isolated from.
+
+**Design the seam without building the tiers (e.g., a `tenant_id` field everywhere, unused)**
+
+Considered as a middle ground. Rejected for now specifically because
+there's no concrete schema or implementation yet to add the field to —
+this is a planning-phase ADR, not a data-modeling one. This option should
+be re-evaluated at the point actual data models are designed in Phase 1,
+since it's cheap to do then and the tradeoff calculus may differ once
+there's real schema to look at.
+
+---
+
+## Related
+
+- `docs/planning/CHARTER.md`
+- `docs/planning/ROADMAP.md`
+- `docs/decisions/adr-0005-deferred-decisions-log.md`

--- a/docs/decisions/adr-0003-outbound-only-agent-comms.md
+++ b/docs/decisions/adr-0003-outbound-only-agent-comms.md
@@ -1,0 +1,116 @@
+# ADR-0003 — Outbound-Only Agent Communication, Identity Deferred
+
+| Field         | Value         |
+| ------------- | ------------- |
+| Status        | ACCEPTED      |
+| Date          | 2026-06-28    |
+| Deciders      | Jason Scherer |
+| Superseded By |               |
+
+## Revision History
+
+| Version | Date       | Author        | Notes   |
+| ------- | ---------- | ------------- | ------- |
+| 1.0     | 2026-06-28 | Jason Scherer | Initial |
+
+---
+
+## Context
+
+The original plan had the Smidr agent connect outbound only — it never
+listens on a port, and the server never opens a connection to it.
+Combined with that, each agent was to receive a unique certificate-based
+identity for authentication and precise revocation.
+
+The reasoning behind outbound-only connectivity (no firewall exceptions
+needed, no inbound attack surface, works through whatever NAT/firewall
+the network already has) is sound regardless of who's running the agent
+or how many agents there are — it's a property of the connection model,
+not of scale or multi-tenancy. The reasoning behind per-agent
+certificate identity, on the other hand, is specifically about
+defending against a compromised or untrusted agent/network — a problem
+that doesn't exist yet when the only network involved is the author's
+own.
+
+## Decision Drivers
+
+- The outbound-only connection model has no real downside even at solo
+  scale — it's free to keep
+- Per-agent certificate issuance, rotation, and revocation is real
+  implementation work whose entire purpose is defending against a
+  scenario (an agent on a network the author doesn't fully control, or a
+  compromised agent) that doesn't apply during Phase 1
+  (`docs/planning/ROADMAP.md`)
+- Building real agent security later, once it's actually needed, is
+  preferable to building a simplified version now and trusting it to be
+  "good enough" later — security mechanisms that were never seriously
+  threat-modeled tend to give false confidence
+
+## Decision
+
+Keep the outbound-only pull model: the agent always initiates the
+connection; the server never connects to the agent.
+
+Defer per-agent certificate identity (mTLS, CA, enrollment tokens,
+revocation) entirely for this phase. The simplest authentication
+sufficient for a single agent on the author's own trusted network is
+acceptable for now.
+
+This is a hard line, not a soft one: **per-agent certificate identity
+must be designed and built for real before any agent runs on a network
+the author does not fully control, and before any non-solo beta.** That
+trigger is recorded in `adr-0005-deferred-decisions-log.md`.
+
+## Consequences
+
+**Positive:**
+
+- Removes certificate issuance, rotation, revocation, and enrollment-token
+  bootstrap entirely from the MVP's scope
+- Keeps the one architectural property worth keeping for free (outbound-
+  only) without paying for the property that isn't needed yet
+  (per-agent identity)
+
+**Accepted tradeoffs:**
+
+- The MVP's agent authentication is intentionally weaker than the
+  long-term design. This is acceptable only because the deployment
+  surface is the author's own trusted network — it would not be
+  acceptable in any other context, which is exactly why the trigger
+  condition above exists
+
+**Negative:**
+
+- None identified, given the trigger condition is honored
+
+**Neutral / follow-up:**
+
+- When the trigger condition is met, design real per-agent certificate
+  identity from scratch — the reasoning summarized in this ADR's Context
+  section is a starting point, not a design to copy verbatim
+
+---
+
+## Alternatives Considered
+
+**Build full per-agent mTLS identity now**
+
+This is the right long-term answer and was the original plan. Rejected
+for this phase specifically because it defends against a threat model
+(an untrusted network, a compromised agent, multiple distinct
+deployments) that doesn't exist yet, and building it now spends scarce
+time on a problem that isn't real today.
+
+**Drop the outbound-only model too, for simplicity**
+
+Considered, but rejected — unlike per-agent identity, outbound-only
+connectivity has no cost to keep even at solo scale, and abandoning it
+now would mean redesigning the connection model later for no benefit
+gained in the meantime.
+
+---
+
+## Related
+
+- `docs/decisions/adr-0005-deferred-decisions-log.md`
+- `docs/planning/ROADMAP.md`

--- a/docs/decisions/adr-0004-modular-boundaries-event-driven-comms.md
+++ b/docs/decisions/adr-0004-modular-boundaries-event-driven-comms.md
@@ -1,0 +1,117 @@
+# ADR-0004 — Modular Boundaries with Event-Driven Internal Communication, Scaled Down
+
+| Field         | Value         |
+| ------------- | ------------- |
+| Status        | ACCEPTED      |
+| Date          | 2026-06-28    |
+| Deciders      | Jason Scherer |
+| Superseded By |               |
+
+## Revision History
+
+| Version | Date       | Author        | Notes   |
+| ------- | ---------- | ------------- | ------- |
+| 1.0     | 2026-06-28 | Jason Scherer | Initial |
+
+---
+
+## Context
+
+The original plan called for a modular monolith: a single deployable unit
+made of cleanly bounded modules that communicate only through a shared
+message bus, never by calling each other's internals directly — so any
+module could later be split into its own service without changing the
+contract. That reasoning was built around 23 modules and an eventual
+MSP-scale deployment.
+
+This phase has three to four modules (`docs/modules/MODULES.md`) and one
+user. The question this ADR answers: does the *concept* of bounded
+modules talking through events, rather than direct calls, still earn its
+keep at this much smaller scale — or is it premature structure for a
+project this size?
+
+## Decision Drivers
+
+- Even with three modules, "agent reports health" → "monitoring displays
+  it" → "a task gets linked to a machine" are naturally separate
+  concerns, and keeping them decoupled costs little extra at this scale
+- Retrofitting clean boundaries after code has been written with direct,
+  tangled calls between concerns is a real, well-known cost — cheaper to
+  keep the boundary from the start than to impose it later
+- Splitting into separate deployable services is explicitly *not* a goal
+  for this phase (over-engineering for a single self-hosted instance) —
+  the value being kept here is the boundary discipline, not the
+  deployment flexibility
+- Limited time means any pattern adopted needs to be simple to actually
+  follow at 5-10 hrs/week, not theoretically clean but tedious in
+  practice
+
+## Decision
+
+Keep the concept: Yggdrasil ships as a single deployable unit (a modular
+monolith), and the in-scope modules (Smidr, Heimdallr, Mimir, Tyr)
+communicate through events/messages rather than reaching into each
+other's internals directly.
+
+Scale down what that means in practice for this phase:
+
+- Three to four modules, not 23
+- No requirement that this be split into separate services, ever — that
+  motivation from the original plan is explicitly not a goal right now
+- The specific message bus technology is an implementation decision, not
+  an architecture decision, and is out of scope for this ADR (see
+  `docs/planning/CHARTER.md` — programming language and stack choices are
+  being deferred past this planning phase)
+
+## Consequences
+
+**Positive:**
+
+- Keeps modules honest about what they depend on, even with only one
+  developer who could otherwise take shortcuts under time pressure
+- Avoids a rewrite if/when more modules get added in Phase 3, since the
+  communication pattern won't need to change, only grow
+
+**Accepted tradeoffs:**
+
+- Slightly more structure up front than the absolute fastest path to a
+  working prototype would have
+- This is accepted because the original plan's own experience already
+  showed what happens when structure is skipped early and time is spent
+  retrofitting it later (the project went through three separate language
+  migrations before anything was dogfooded)
+
+**Negative:**
+
+- None identified at this scale
+
+**Neutral / follow-up:**
+
+- Revisit whether services should actually be split out only if a
+  concrete operational reason appears (e.g., one module needs independent
+  scaling or a different deployment target) — not preemptively
+
+---
+
+## Alternatives Considered
+
+**Drop module boundaries entirely for the MVP; one monolithic blob of code**
+
+Fastest to a working prototype. Rejected because the original plan's own
+history (three language migrations, a 23-module redesign) is direct
+evidence that skipping structure early on this project specifically tends
+to cost more later than it saves now.
+
+**Build for eventual service splitting now (separate deployable processes per module)**
+
+This was closer to the original plan's ambition. Rejected for this phase
+— there is one user and one deployment target; the operational cost of
+multiple processes (deployment, networking, debugging across process
+boundaries) has no current benefit.
+
+---
+
+## Related
+
+- `docs/modules/MODULES.md`
+- `docs/planning/CHARTER.md`

--- a/docs/decisions/adr-0005-deferred-decisions-log.md
+++ b/docs/decisions/adr-0005-deferred-decisions-log.md
@@ -1,0 +1,109 @@
+# ADR-0005 — Deferred Decisions Log
+
+| Field         | Value         |
+| ------------- | ------------- |
+| Status        | ACCEPTED      |
+| Date          | 2026-06-28    |
+| Deciders      | Jason Scherer |
+| Superseded By |               |
+
+## Revision History
+
+| Version | Date       | Author        | Notes   |
+| ------- | ---------- | ------------- | ------- |
+| 1.0     | 2026-06-28 | Jason Scherer | Initial |
+
+---
+
+## Context
+
+This restart deliberately scoped down a much larger original plan (see
+`docs/planning/CHARTER.md`). Scoping down means a number of real
+decisions are being postponed rather than made. Postponed decisions that
+aren't written down tend to either get forgotten or get quietly
+re-decided by default (i.e., never revisited, which is itself a decision
+nobody chose deliberately).
+
+This is not a typical single-decision ADR. It's a living register of
+decisions intentionally not made yet, each with the specific condition
+that should trigger revisiting it. It should be updated in place as items
+are resolved or new deferrals are identified, rather than superseded by a
+new numbered ADR each time.
+
+## Decision Drivers
+
+- A solo, part-time project needs an honest, low-overhead way to track
+  "not deciding this yet" without it turning into "never deciding this"
+- Each deferral needs a concrete trigger condition, not a vague "later",
+  so it's actually possible to know when to revisit it
+- This register should be checked before starting Phase 3 work
+  (`docs/planning/ROADMAP.md`)
+
+## Decision
+
+Maintain this table as the single source of truth for deferred
+decisions:
+
+| Item | Deferred by | Why deferred | Revisit when |
+| --- | --- | --- | --- |
+| Three-tier tenancy (Platform Owner / Tenant / SubTenant) | ADR-0002 | Single user, no second organization exists yet | A real second user/organization needs to use the platform |
+| Per-agent mTLS identity (certificates, CA, revocation, enrollment tokens) | ADR-0003 | Agent only runs on the author's own trusted network | An agent needs to run on a network the author doesn't fully control, or before any non-solo beta |
+| WASM plugin sandbox / plugin system | This ADR | No concrete plugin use case exists yet | A real, specific plugin need shows up from actual usage |
+| Licensing model (currently BUSL 1.1, inherited from the original plan) | This ADR | Inherited default, not yet re-evaluated against the smaller/solo scope or the build-in-public plan | Before any public sharing of source, before accepting outside contributions, or before Phase 2 build-in-public activity scales up |
+| Remaining ~19-20 modules from the original 23-module catalog | `docs/modules/MODULES.md` | Out of scope for the dogfood MVP | One at a time, re-justified against real usage evidence, per the roadmap — not pre-committed as a batch |
+| Split-service deployment (modules as separate processes) | ADR-0004 | No operational reason for it yet; single self-hosted instance | A concrete operational reason appears (independent scaling, different deployment target for one module) |
+
+## Consequences
+
+**Positive:**
+
+- Deferred work is visible and intentional, not silently dropped
+- Each item has a clear, checkable trigger instead of a vague "someday"
+- Future-self (or anyone else looking at this project) can tell the
+  difference between "decided against" and "not decided yet"
+
+**Accepted tradeoffs:**
+
+- This table needs upkeep — it's only useful if it's actually consulted
+  and updated, which is itself an ongoing cost on a project with very
+  little spare time
+
+**Negative:**
+
+- A trigger condition being met doesn't get enforced automatically; it
+  relies on the author noticing and checking this file
+
+**Neutral / follow-up:**
+
+- Review this table at the start of any Phase 3 work
+  (`docs/planning/ROADMAP.md`)
+- Add new rows as new deferrals are identified during Phase 1/2
+
+---
+
+## Alternatives Considered
+
+**Don't track deferred decisions explicitly; handle each as it comes up**
+
+Simpler in the moment. Rejected because the gaps between work sessions on
+a 5-10 hr/week solo project make it likely that an undocumented deferral
+gets forgotten entirely, or re-litigated from scratch each time it
+resurfaces.
+
+**Write a separate full ADR for each deferral instead of one shared table**
+
+More in line with normal ADR practice. Rejected for the deferrals
+specifically (as opposed to the decisions that caused them, which do
+have their own ADRs — 0002, 0003, 0004) because a single table is easier
+to scan and keep current than several small files that would mostly
+just restate "not decided yet."
+
+---
+
+## Related
+
+- `docs/planning/CHARTER.md`
+- `docs/planning/ROADMAP.md`
+- `docs/decisions/adr-0002-mvp-single-tenant-scope.md`
+- `docs/decisions/adr-0003-outbound-only-agent-comms.md`
+- `docs/decisions/adr-0004-modular-boundaries-event-driven-comms.md`

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -1,0 +1,65 @@
+# ADR-XXXX — <Short, decision-oriented title>
+
+| Field         | Value         |
+| ------------- | ------------- |
+| Status        | PROPOSED      |
+| Date          | YYYY-MM-DD    |
+| Deciders      | Jason Scherer |
+| Superseded By |               |
+
+## Revision History
+
+| Version | Date       | Author        | Notes   |
+| ------- | ---------- | ------------- | ------- |
+| 1.0     | YYYY-MM-DD | Jason Scherer | Initial |
+
+---
+
+## Context
+
+What's the situation forcing this decision? What constraints — technical,
+business, time/capacity, security — are in play? Describe the problem
+space, not the solution.
+
+## Decision Drivers
+
+- Driver 1
+- Driver 2
+- Driver 3
+
+## Decision
+
+The actual decision, stated plainly.
+
+## Consequences
+
+**Positive:**
+
+- ...
+
+**Accepted tradeoffs:**
+
+- ...
+
+**Negative:**
+
+- ...
+
+**Neutral / follow-up:**
+
+- ...
+
+## Alternatives Considered
+
+**Alternative name**
+
+Prose describing what it was, why it was attractive, and the specific
+reason it lost out.
+
+**Alternative name**
+
+Same treatment for each option seriously considered.
+
+## Related
+
+- Links to related ADRs, docs, or external references

--- a/docs/modules/MODULES.md
+++ b/docs/modules/MODULES.md
@@ -1,0 +1,75 @@
+# Yggdrasil — Module Catalog
+
+The original plan defined 23 Norse-named modules for a full
+MSP/PSA/RMM/CRM/ERP platform. This restart keeps the catalog as
+reference and keeps the naming, but only a small slice is actually in
+scope right now (`docs/planning/CHARTER.md`,
+`docs/planning/ROADMAP.md`). Everything else is deferred and will be
+re-justified individually, against real usage evidence, when it's
+actually reached — not pre-committed as a batch (see
+`docs/decisions/adr-0005-deferred-decisions-log.md`).
+
+## In Scope — Phase 1 MVP
+
+**Smidr — Agent**
+Runs on the author's own machines, connects outbound only (never
+listens), and reports basic health/inventory. No per-agent certificate
+identity yet — see `docs/decisions/adr-0003-outbound-only-agent-comms.md`.
+Scaled down from the original orchestration-layer vision (enrollment,
+boot triggers, build coordination) to just: connect, report, receive
+simple commands.
+
+**Heimdallr — Monitoring**
+Receives what Smidr reports and displays fleet/machine health at a
+glance. Scaled down from the original (time-series storage, anomaly
+feeds to Völva, SLO management) to: collect, store, display.
+
+**Mimir — Tasks/Tickets**
+Tracks the author's own tasks and projects, linked to the machine(s) they
+relate to. Scaled down from the original (full epics/sprints, commit/PR
+linking, CI/CD timeline integration) to: create, track, and link tasks
+to machines.
+
+**Tyr — Minimal Auth**
+Single-user login only, just enough to gate access to the instance. This
+is not the identity module from the original catalog (no OIDC
+federation, no per-permission JWT claims, no certificate issuance for
+agents) — those are deferred along with multi-tenancy and agent identity.
+
+## Future Catalog (Reference Only — Not In Scope)
+
+Kept here as the re-justification checklist for Phase 3
+(`docs/planning/ROADMAP.md`). One-line summaries carried forward from
+the original plan; each needs to be re-justified against real evidence
+before being picked up, not assumed.
+
+| Module | Original purpose |
+| --- | --- |
+| Valhalla | Tenant/admin management — moot until there's more than one tenant |
+| Urd | Immutable audit trail and compliance logging |
+| Gjallarhorn | SLA enforcement and escalation on top of Mimir's work items |
+| Bragi | Internal notes and contextual team communication |
+| Saga | Scheduling/calendar coordination for technician availability |
+| Odin | Internal/external knowledge base and runbooks |
+| Ymir | CI/CD visibility, build/release tracking |
+| Eir | Remote diagnostics and remediation via Smidr |
+| Ran | Backup job monitoring (not performing backups itself) |
+| Vedfolnir | CVE/security posture tracking, patch compliance |
+| Volva | ML-based predictive intelligence on top of Heimdallr telemetry |
+| Skald | Reporting/analytics across platform data; doc validation tooling |
+| Freyja | Hardware/software asset lifecycle registry |
+| Forseti | Contracts, billing, renewal workflows |
+| Sigrun | Automated client onboarding/provisioning |
+| Verdandi | Notification delivery fabric (email, webhook, push) |
+| Hermod | External integrations and API gateway |
+| Loki | Automation/workflow builder across modules |
+| Bifrost | Customer-facing self-service portal |
+
+## Related
+
+- `docs/planning/CHARTER.md`
+- `docs/planning/ROADMAP.md`
+- `docs/decisions/adr-0002-mvp-single-tenant-scope.md`
+- `docs/decisions/adr-0003-outbound-only-agent-comms.md`
+- `docs/decisions/adr-0004-modular-boundaries-event-driven-comms.md`
+- `docs/decisions/adr-0005-deferred-decisions-log.md`

--- a/docs/planning/CHARTER.md
+++ b/docs/planning/CHARTER.md
@@ -1,0 +1,120 @@
+# Yggdrasil — Project Charter
+
+## Status
+
+This charter reflects a deliberate restart. The original plan scoped
+Yggdrasil as a 23-module MSP/gov-contractor platform before any of it had
+been used by a real person for a real day. This
+version scopes down to what one person, working 5-10 hours a week, can
+actually build and use — with the larger platform as a direction to grow
+into, not a day-one requirement.
+
+## Origin
+
+This isn't a market-sized opportunity in search of a product. It comes
+from lived frustration: a government IT department that's disorganized
+in the specific, familiar ways most IT shops are; a broader trend of
+organizations stretching hardware lifespans further than they used to,
+which makes fleet visibility matter more, not less; and the daily
+annoyance of stitching together multiple disconnected tools just to get
+one coherent view of what's going on.
+
+The author has eight years of hands-on IT experience, is now working as
+a software engineer, and runs a homelab. That combination — having lived
+the problem, and now having the skills to build a real solution to it —
+is the actual reason this project exists.
+
+## Vision
+
+**Near-term:** A self-hosted tool the author actually uses to track tasks
+and monitor the health of their own homelab machines, end to end —
+proving the core loop (agent reports in, work gets tracked, both are
+visible in one place) before anything else is built.
+
+**Long-term direction (not a current commitment):** A unified,
+self-hosted operations platform — monitoring, ticketing, and the rest of
+the old module catalog — for people and organizations who are tired of
+stitching together separate RMM, PSA, CRM, and billing tools. Air-gapped
+and source-visible deployment remain part of the long-term identity
+because they matter to the author personally (privacy, self-hosting,
+auditability), not because a specific paying segment has confirmed they
+need it yet.
+
+## Problem Statement
+
+**What's confirmed (the author's own experience):**
+
+- IT operations data is scattered across disconnected tools with no
+  unified view, even at small scale
+- Hardware is being kept in service longer, which raises the cost of not
+  having good fleet/health visibility
+- Switching between separate ticketing, monitoring, and asset tools to
+  understand "what's actually going on" is a real, recurring cost
+
+**What's not yet confirmed:** Whether MSPs, government contractors, or
+anyone other than the author feel this strongly enough to adopt or pay
+for a tool that solves it. That's an open question this phase is designed
+to start answering, not an assumption to build 23 modules on top of.
+
+## Who This Is For Right Now
+
+The author, as a homelab user and practitioner — full stop. Every
+decision in this phase is judged by "does this make my own setup better"
+first. MSP and government/defense personas from the old charter are
+retained as the long-term direction (see Non-Goals and the Roadmap), not
+as current target users.
+
+## Success Criteria
+
+**For this phase (next ~3 months, ~5-10 hrs/week):**
+
+- A self-hosted instance is running on the author's own network
+- A lightweight agent reports health/inventory from at least one real
+  homelab machine
+- Tasks/tickets for the author's own projects are tracked in the same
+  system, visibly connected to the machines they relate to
+- The author is actually using it instead of whatever they used before
+
+**Long term (unscoped, revisited as the roadmap progresses):**
+
+- Evidence — not assumption — that people outside the author want this
+- A sustainable path (commercial, open-source, or otherwise) that hasn't
+  been decided yet — see `docs/decisions/adr-0005-deferred-decisions-log.md`
+
+## Non-Goals (for this phase)
+
+- Not building multi-tenant/multi-organization support
+- Not building production-grade agent identity (per-agent certs,
+  revocation) — the agent only runs on the author's own trusted network
+  for now
+- Not building a plugin system — there's no plugin yet that needs one
+- Not deciding the long-term licensing model yet
+- Not building out the full 23-module catalog — see
+  `docs/modules/MODULES.md` for what's in scope now vs. deferred
+
+## Guiding Principles
+
+- Build for yourself first; let outside validation follow real usage,
+  not precede it
+- Practical architecture over hype — premature complexity gets
+  challenged, especially given the solo/part-time reality of this project
+- Every significant decision still gets an ADR, even at this scale —
+  small projects lose context just as easily as big ones
+- Honest tradeoff assessment over optimistic framing, including about
+  scope and pace
+- A deferred decision is not a forgotten one — see the deferred decisions
+  log and revisit it as conditions change
+
+## Deployment Model (this phase)
+
+Single self-hosted instance, on the author's own home network. No SaaS,
+no multi-tenant hosting, no air-gapped deployment target yet — those
+remain long-term direction, not near-term work.
+
+## License
+
+Currently Business Source License 1.1 (see `LICENSE`), inherited from the
+original plan. This is explicitly under reconsideration — see
+`docs/decisions/adr-0005-deferred-decisions-log.md` — and should be
+treated as provisional until revisited, particularly before any public
+build-in-public sharing or outside contribution.

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -1,0 +1,71 @@
+# Yggdrasil — Roadmap
+
+This roadmap assumes solo work at roughly 5-10 hours/week. Phases are
+sequential by design — each one is meant to produce evidence that justifies
+moving to the next, rather than scope being committed up front.
+
+## Phase 0 — Planning (current)
+
+- Restate vision and problem statement around actual lived experience
+  (`docs/planning/CHARTER.md`)
+- Re-scope the module catalog down to an MVP slice (`docs/modules/MODULES.md`)
+- Record the architecture concepts being carried forward, and which ones
+  are explicitly deferred (`docs/decisions/`)
+
+**Exit condition:** A scoped MVP definition exists that fits in the
+3-month / 5-10 hr-per-week budget.
+
+## Phase 1 — Dogfood MVP
+
+Build the smallest end-to-end loop across three modules:
+
+- **Smidr** (agent) — runs on at least one of the author's own machines,
+  connects outbound, reports basic health/inventory. No per-agent
+  certificate identity yet (see ADR-0003); the network is trusted because
+  it's the author's own.
+- **Heimdallr** (monitoring) — receives and displays what Smidr reports.
+  Enough to answer "is this machine okay" at a glance.
+- **Mimir** (tasks/tickets) — tracks the author's own tasks/projects, with
+  a visible link to the machine(s) they relate to.
+- **Tyr** (minimal auth) — single-user login only. Not the full identity
+  module from the old catalog — just enough to gate access.
+
+Single-tenant throughout (ADR-0002). No plugin system (ADR-0005).
+
+**Exit condition:** The author is using this instead of whatever
+combination of tools they used before, for at least a few real weeks.
+
+## Phase 2 — Build in Public + Dogfood
+
+Runs partly in parallel with Phase 1, conditions allowing (the author is
+setting up a dedicated workspace that should help this along):
+
+- Share progress periodically (devlog/repo updates) in homelab/sysadmin
+  spaces
+- Show the MVP directly to IT colleagues/contacts the author already has
+  access to and ask directly whether it solves something for them
+- Treat this as listening, not marketing — the goal is evidence, not an
+  audience
+
+**Exit condition:** Some signal — positive or negative — about whether
+this is wanted beyond the author. Either outcome is useful; "nobody else
+needs this" is a valid result that keeps the project scoped to personal
+use.
+
+## Phase 3 — Conditional Expansion
+
+Only enter this phase based on what Phase 1/2 actually showed, and only
+for the specific items that have a real trigger (see
+`docs/decisions/adr-0005-deferred-decisions-log.md`):
+
+- Multi-tenancy, if a second real user/org shows up
+- Agent mTLS/per-agent identity, if an agent needs to run somewhere outside
+  the author's own trusted network, or before any non-solo beta
+- Plugin system, if a concrete plugin use case shows up
+- Licensing model decision, before any public sharing of source or
+  accepting outside contributions
+- Additional modules from the original 23-module catalog, picked up one
+  at a time and re-justified against current evidence, not pre-committed
+
+There is no fixed timeline for Phase 3 — it starts when its trigger
+conditions are met, not on a calendar date.


### PR DESCRIPTION
Replaces the original 23-module MSP-platform plan with a from-scratch charter, roadmap, and ADR set scoped to what's actually buildable solo at 5-10 hrs/week: a minimal agent + monitoring + tasks loop, single tenant, with multi-tenancy, agent mTLS identity, and the plugin system explicitly deferred and tracked in a deferred-decisions log.